### PR TITLE
Example of a script to emulate switch, but turning on twice resets brightness

### DIFF
--- a/hue_switch_reset.js
+++ b/hue_switch_reset.js
@@ -1,0 +1,70 @@
+let CONFIG = {
+    ip: '192.168.178.168', //Hue Bridge IP
+    user: 'S4DAeeXgjRj92sTwu7uNm6m7cqCz0dAyDNaDi0IO', //Hue Bridge API user
+    light: '2', // Hue Light ID
+    input1: 0, // Shelly Button ID
+};
+
+// Set Switch detached
+Shelly.call("Input.SetConfig", {
+    id: 0,
+    config: {
+        type: "switch",
+    },
+});
+
+Shelly.call("Switch.SetConfig", {
+    id: 0,
+    config: {
+        in_mode: "detached",
+        initial_state: "on"
+    },
+});
+
+
+// add an evenHandler 
+Shelly.addEventHandler(
+    function (event, user_data) {
+       
+        if (typeof event.info.state !== 'undefined') {
+          if (event.info.id === CONFIG.input1) {
+                // Get the current light state
+                Shelly.call(
+                    "http.request", {
+                    method: "GET",
+                    url: 'http://' + CONFIG.ip + '/api/' + CONFIG.user + '/lights/' + CONFIG.light,
+                },
+                    function (res, error_code, error_message, ud) {
+                        let st = JSON.parse(res.body);
+                        if (st.state.on === true) {
+                            Toggle("false");
+                        } else {
+                            Toggle("true");
+
+                        }
+                    },
+                    null
+                );
+            } else {
+                return true;
+            }
+        } else {
+            return true;
+        }
+    },
+);
+
+function Toggle(state) {
+    let b = '{"on": ' + state + '}';
+
+    Shelly.call(
+        "http.request", {
+        method: "PUT",
+        url: 'http://' + CONFIG.ip + '/api/' + CONFIG.user + '/lights/' + CONFIG.light + '/state',
+        body: b
+    },
+        function (r, e, m) {
+        },
+        null
+    );
+}

--- a/hue_switch_reset.js
+++ b/hue_switch_reset.js
@@ -34,41 +34,27 @@ Shelly.addEventHandler(
         if (typeof event.info.state !== 'undefined' && event.info.id === CONFIG.input1) {
             if (event.info.state) {
                 if (CONFIG.recent) {
-                    BrightLight();
+                    SetLight('{"ct": 500, "bri": 254, "on": true}');
                 } else {
                     CONFIG.recent = true
                     Timer.set(15 * 1000, false, ClearRecent)
-                    SetLight("true");
+                    SetLight('{"on": true}');
                 }
             } else {
-                SetLight("false");
+                SetLight('{"on": false}');
             }
         }
     },
+    null,
 );
 
-function BrightLight() {
+function SetLight(b) {
     Shelly.call(
         "http.request", {
-        method: "PUT",
-        url: 'http://' + CONFIG.ip + '/api/' + CONFIG.user + '/groups/' + CONFIG.groups + '/action',
-        body: '{"ct": 500, "bri": 254, "on": true}'
-    },
-        function (r, e, m) {
+            method: "PUT",
+            url: 'http://'+ CONFIG.ip +'/api/'+ CONFIG.user +'/groups/'+ CONFIG.groups +'/action',
+            body: b
         },
-        null
-    );
-}
-
-function SetLight(state) {
-    let b = '{"on": ' + state + '}';
-
-    Shelly.call(
-        "http.request", {
-        method: "PUT",
-        url: 'http://' + CONFIG.ip + '/api/' + CONFIG.user + '/groups/' + CONFIG.groups + '/action',
-        body: b
-    },
         function (r, e, m) {
         },
         null

--- a/hue_switch_reset.js
+++ b/hue_switch_reset.js
@@ -2,8 +2,9 @@ let CONFIG = {
     ip: '192.168.<ip.number>', //Hue Bridge IP
     user: '<api-key>', //Hue Bridge API user
     groups: '3', // Hue Groups ID
-    input1: 0, // Shelly Button ID
-    recent: false // has been recently turned on
+    input1: 0, // Shelly Switch ID
+    recent: false, // has been recently turned on
+    recent_sec: 15 // number of seconds to consider recent
 };
 
 // Callback to clear recent
@@ -13,14 +14,14 @@ function ClearRecent() {
 
 // Set Switch detached
 Shelly.call("Input.SetConfig", {
-    id: 0,
+    id: CONFIG.input1,
     config: {
         type: "switch",
     },
 });
 
 Shelly.call("Switch.SetConfig", {
-    id: 0,
+    id: CONFIG.input1,
     config: {
         in_mode: "detached",
         initial_state: "on"
@@ -37,7 +38,7 @@ Shelly.addEventHandler(
                     SetLight('{"ct": 500, "bri": 254, "on": true}');
                 } else {
                     CONFIG.recent = true
-                    Timer.set(15 * 1000, false, ClearRecent)
+                    Timer.set(CONFIG.recent_sec * 1000, false, ClearRecent)
                     SetLight('{"on": true}');
                 }
             } else {


### PR DESCRIPTION
I'm using a Shelly plus 1 to allow my light switch to behave like a switch, but controlling the hue programmatically. However I also liked the behavior of power cycling the hue lights to restore full brightness occasionally. This script gives the best of both worlds. It keeps power to the hue lights all the time, and behaves like a normal switch, unless toggled on twice within 15 seconds, in which case it turns the hue lights up to full brightness.