### PR TITLE
Update monitor_remote_consumption.js

### DIFF
--- a/monitor_remote_consumption.js
+++ b/monitor_remote_consumption.js
@@ -46,7 +46,11 @@ function startMonitor() {
                     url: 'http://' + remoteip + '/status'
                 },
                 function (res, error_code, error_msg, ud) {
-                    if (res.code === 200) {
+                    if (error_code !== 0)
+                    {
+                        // Not read response if there is an error, to avoid that the script stops
+                    }
+                    else if (res.code === 200) {
                         let st = JSON.parse(res.body);
                         let current = st.meters[0].power;
                         if (current > minUsage) {


### PR DESCRIPTION
res must not be read if there is an error. Otherwise, when the are WIFI problems, or the target device is accessible, the script will be stopped.